### PR TITLE
Support user configuration of routeBasePath and path

### DIFF
--- a/packages/docusaurus-protobuffet-plugin/src/index.ts
+++ b/packages/docusaurus-protobuffet-plugin/src/index.ts
@@ -6,9 +6,14 @@ import { generateDocFiles, generateSidebarFileContents } from './generators';
 import { parseFileDescriptors } from './parsers';
 
 export interface PluginOptions {
+  // Path to Protobuf file descriptors JSON file. See: https://protobuffet.com/docs/how/usage#generating-the-filedescriptorspath-file
   fileDescriptorsPath: string
+  // Path to generate data on filesystem relative to site dir.
   protoDocsPath: string;
+  // Path to sidebar configuration for showing a list of markdown pages.
   sidebarPath: string;
+  // URL route for the docs section of your site.
+  routeBasePath: string;
 }
 
 export function validateOptions({ options, validate }: { options: PluginOptions, validate: () => void }): PluginOptions {
@@ -46,7 +51,7 @@ export default function plugin(
         .action(() => {
           // read file descriptors JSON file
           const fileDescriptorsInput = JSON.parse(readFileSync(options.fileDescriptorsPath).toString());
-          const fileDescriptors = parseFileDescriptors(fileDescriptorsInput);
+          const fileDescriptors = parseFileDescriptors(fileDescriptorsInput, options.routeBasePath);
 
           // generate markdown files for each in fileDescriptors
           const docFiles = generateDocFiles(fileDescriptors);

--- a/packages/docusaurus-protobuffet-plugin/src/parsers.ts
+++ b/packages/docusaurus-protobuffet-plugin/src/parsers.ts
@@ -13,7 +13,9 @@ export const parseFileDescriptors = (source: object, routeBasePath: string): Fil
   const enumLinkMap: LinkMap = {}
 
   const generateLink = (fileName: string, objName: string): string => {
-    return `${routeBasePath === '/' ? '' : routeBasePath}/${fileName}#${objName.toLowerCase().replace(/\./g, '')}`
+    // NOTE: ensure prefixed with '/'
+    const routeBase = routeBasePath.startsWith('/') ? routeBasePath : `/${routeBasePath}`;
+    return `${routeBase === '/' ? '' : routeBase}/${fileName}#${objName.toLowerCase().replace(/\./g, '')}`
   }
 
   // derive link maps

--- a/packages/docusaurus-protobuffet-plugin/src/parsers.ts
+++ b/packages/docusaurus-protobuffet-plugin/src/parsers.ts
@@ -4,7 +4,7 @@ interface LinkMap {
   [key: string]: string;
 }
 
-export const parseFileDescriptors = (source: object): FileDescriptors => {
+export const parseFileDescriptors = (source: object, routeBasePath: string): FileDescriptors => {
   // TODO: add joi validations
   const parsed = source as FileDescriptors;
 
@@ -13,8 +13,7 @@ export const parseFileDescriptors = (source: object): FileDescriptors => {
   const enumLinkMap: LinkMap = {}
 
   const generateLink = (fileName: string, objName: string): string => {
-    // TODO: reference option for base path
-    return `/protodocs/${fileName}#${objName.toLowerCase().replace(/\./g, '')}`
+    return `${routeBasePath === '/' ? '' : routeBasePath}/${fileName}#${objName.toLowerCase().replace(/\./g, '')}`
   }
 
   // derive link maps

--- a/packages/docusaurus-protobuffet/src/index.ts
+++ b/packages/docusaurus-protobuffet/src/index.ts
@@ -1,9 +1,14 @@
 import { LoadContext } from '@docusaurus/types';
 
 interface PluginOptions {
+  // Path to Protobuf file descriptors JSON file. See: https://protobuffet.com/docs/how/usage#generating-the-filedescriptorspath-file
   fileDescriptorsPath: string
+  // Path to generate data on filesystem relative to site dir.
   protoDocsPath?: string;
+  // Path to sidebar configuration for showing a list of markdown pages.
   sidebarPath?: string;
+  // URL route for the docs section of your site. Not configurable by user, is assigned using doc option's routeBasePath.
+  routeBasePath?: string;
 }
 
 const pluginOptionDefaults = {
@@ -11,8 +16,17 @@ const pluginOptionDefaults = {
   sidebarPath: './sidebarsProtodocs.js',
 }
 
+// NOTE: these are options exposed by docusaurus plugin-content-docs: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs
 interface ContentDocOptions {
+  // URL route for the docs section of your site.
+  routeBasePath?: string;
+  // Path to sidebar configuration for showing a list of markdown pages.
   sidebarPath?: string;
+}
+
+const contentDocOptionsDefaults = {
+  routeBasePath: 'protodocs',
+  sidebarPath: './sidebarsProtodocs.js',
 }
 
 interface PresetOptions {
@@ -28,7 +42,11 @@ export default function preset(
     ...pluginOptionDefaults,
     ...options.protobuffet
   };
-  const docSidebarPath = options.docs?.sidebarPath || pluginOptions.sidebarPath;
+  const contentDocOptions: ContentDocOptions = {
+    ...contentDocOptionsDefaults,
+    ...options.docs,
+  }
+  pluginOptions.routeBasePath = contentDocOptions.routeBasePath;
 
   const config = {
     plugins: [
@@ -40,9 +58,9 @@ export default function preset(
         '@docusaurus/plugin-content-docs',
         {
           id: 'protodocs',
-          path: 'protodocs',
-          routeBasePath: 'protodocs',
-          sidebarPath: docSidebarPath,
+          path: pluginOptions.protoDocsPath,
+          routeBasePath: contentDocOptions.routeBasePath,
+          sidebarPath: contentDocOptions.sidebarPath,
         },
       ],
     ],

--- a/packages/docusaurus-protobuffet/src/index.ts
+++ b/packages/docusaurus-protobuffet/src/index.ts
@@ -42,11 +42,15 @@ export default function preset(
     ...pluginOptionDefaults,
     ...options.protobuffet
   };
-  const contentDocOptions: ContentDocOptions = {
+
+  const docOptions = {
+    id: 'protodocs',
+    path: pluginOptions.protoDocsPath,
     ...contentDocOptionsDefaults,
     ...options.docs,
-  }
-  pluginOptions.routeBasePath = contentDocOptions.routeBasePath;
+  };
+
+  pluginOptions.routeBasePath = docOptions.routeBasePath;
 
   const config = {
     plugins: [
@@ -56,12 +60,7 @@ export default function preset(
       ],
       [
         '@docusaurus/plugin-content-docs',
-        {
-          id: 'protodocs',
-          path: pluginOptions.protoDocsPath,
-          routeBasePath: contentDocOptions.routeBasePath,
-          sidebarPath: contentDocOptions.sidebarPath,
-        },
+        docOptions,
       ],
     ],
   };


### PR DESCRIPTION
### Context
Issue #1 reported that "protodocs" is hardcoded to both the `routeBasePath` and the `path` variables passed to `@docusaurus/plugin-content-docs`.

### Problem
The configuration of this base route and docs directory are valid use cases and should be supported.

### Solution
`routeBasePath`
- Expose a new configuration option for `docs.routeBasePath` and pass to docs plugin initialization.
- Use this new config during link generation.

`path`
- Use `protobuffet.protoDocsPath` to populate `path` in the docs plugin initialization.

### Usage
To configure a different directory for documentation to be generated (`npx docusaurus generate-proto-docs`), configure `protobuffet.protoDocsPath`. Note, this will automatically be used for the directory where docs are read from when initializing `@docusaurus/plugin-content-docs`.

To configure a different base route for links, configure `docs.routeBasePath`.

Example:
```js
[
      'docusaurus-protobuffet',
      {
        protobuffet: {
          fileDescriptorsPath: './fixtures/proto_workspace.json',
          protoDocsPath: './protodocs',
          sidebarPath: './generatedSidebarsProtodocs.js',
        },
        docs: {
          sidebarPath: './sidebarsProtodocs.js',
          routeBasePath: 'protodocs-test',
        },
      }
 ]
```