### PR TITLE
Make name of protobuf doc-file a `h1` header

### DIFF
--- a/packages/docusaurus-protobuffet-plugin/src/generators/docfile.ts
+++ b/packages/docusaurus-protobuffet-plugin/src/generators/docfile.ts
@@ -22,7 +22,7 @@ hide_title: true
 
 import { ProtoMessage, ProtoServiceMethod, ProtoEnum } from '@theme/ProtoFile';
 
-## \`${getLeafFileName(fileDescriptor.name)}\`
+# \`${getLeafFileName(fileDescriptor.name)}\`
 _**path** ${fileDescriptor.name}_
 
 _**package** ${fileDescriptor.package}_


### PR DESCRIPTION
Makes the name of the protobuf doc-file a `<h1>` header.

Because `hide_title: true` is set, the protobuf doc-file has no `<h1>` header otherwise.

This causes issues with some tools which expect a `<h1>`.  For example, `docusaurus-lunr-search` only supports searching through files with a `<h1>` header set, see: https://github.com/praveenn77/docusaurus-lunr-search/blob/0f83df127f671c478da90d0b993deb2253b38ae3/src/html-to-doc.js#L40-L43

I think it's pretty unlikely that this change will cause issues anywhere else, but just in case, it might be worth making a simple `CHANGELOG.md` file that lists this change, e.g. something like:

```md
# CHANGELOG.md

## [0.3.2]

### Changed

- Protobuffet output markdown files now start with a h1 header instead of a h2 header
  for better compatibility with third-party tools
```

Thanks for making this project open-source! Those automatically generated protobuf markdown files are gorgeous!

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/19716675/152515609-80ed27e0-1c3a-4b53-be5e-7f87840d0161.png)

### After

Title is slightly larger, since it's now a `h1`, and it's missing from the right sidebar.

![image](https://user-images.githubusercontent.com/19716675/152516082-88966009-ea0a-4bc9-bfbe-0117cc05580e.png)