### PR TITLE
Added option `templatePath` to use custom template for generated MDX

### DIFF
--- a/packages/docusaurus-protobuffet-plugin/package-lock.json
+++ b/packages/docusaurus-protobuffet-plugin/package-lock.json
@@ -247,6 +247,18 @@
         "strip-bom-string": "^1.0.0"
       }
     },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -312,6 +324,16 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -370,6 +392,12 @@
         "has-flag": "^4.0.0"
       }
     },
+    "uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "optional": true
+    },
     "universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -382,6 +410,11 @@
       "requires": {
         "lodash": "^4.17.15"
       }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     }
   }
 }

--- a/packages/docusaurus-protobuffet-plugin/package.json
+++ b/packages/docusaurus-protobuffet-plugin/package.json
@@ -27,7 +27,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@docusaurus/utils": "^2.0.0-alpha.72"
+    "@docusaurus/utils": "^2.0.0-alpha.72",
+    "handlebars": "^4.7.7"
   },
   "devDependencies": {
     "@types/react": "^17.0.3",

--- a/packages/docusaurus-protobuffet-plugin/src/generators/docfile.ts
+++ b/packages/docusaurus-protobuffet-plugin/src/generators/docfile.ts
@@ -1,102 +1,23 @@
-import { Enum, FileDescriptor, FileDescriptors, GeneratedDocFile, Message, Service } from '../types';
-import { getLeafFileName } from '../utils';
+import { FileDescriptors, GeneratedDocFile } from "../types";
+import { getLeafFileName } from "../utils";
+import { compile } from "handlebars";
+import defaultTemplate from "./template";
 
-export const generateDocFiles = (fileDescriptors: FileDescriptors): GeneratedDocFile[] => {
-  const { files }  = fileDescriptors;
-  return files.map(generateDocFile);
+export const generateDocFiles = (
+  fileDescriptors: FileDescriptors,
+  template?: string
+): GeneratedDocFile[] => {
+  const helpers: { [name: string]: Function } = {
+    stringify: JSON.stringify,
+    getLeafFileName,
+  };
+
+  const compiledTemplate = compile(template ?? defaultTemplate);
+
+  const { files } = fileDescriptors;
+  return files.map((fileDescriptor) => ({
+    fileContents: compiledTemplate(fileDescriptor, { helpers }),
+    fileName: fileDescriptor.name,
+    fileDescriptor,
+  }));
 };
-
-const generateDocFile = (fileDescriptor: FileDescriptor): GeneratedDocFile => ({
-  fileContents: generateDocFileContents(fileDescriptor),
-  fileName: fileDescriptor.name,
-  fileDescriptor,
-});
-
-const generateDocFileContents = (fileDescriptor: FileDescriptor): string => {
-  // TODO: run through prettier for consistent formatting.
-  return (
-  `---
-title: ${getLeafFileName(fileDescriptor.name)}
-hide_title: true
----
-
-import { ProtoMessage, ProtoServiceMethod, ProtoEnum } from '@theme/ProtoFile';
-
-# \`${getLeafFileName(fileDescriptor.name)}\`
-_**path** ${fileDescriptor.name}_
-
-_**package** ${fileDescriptor.package}_
-
-${fileDescriptor.description}
-
----
-
-${
-  [
-    generateMessageSectionMdx(fileDescriptor.messages),
-    generateEnumSectionMdx(fileDescriptor.enums),
-    generateServiceSectionMdx(fileDescriptor.services),
-  ].filter(Boolean).map(section => section + "\n---\n").join("")
-}
-
-  `);
-};
-
-const generateMessageSectionMdx = (messages: Message[]): string|null => {
-  if (messages.length == 0) {
-    return null;
-  }
-
-  return (
-    `## Messages
-
-${messages.map((message, i) => (
-`
-### \`${message.longName}\`
-<ProtoMessage key={${i}} message={${JSON.stringify(message)}} />
-`
-)).join("\n")}`
-  );
-};
-
-const generateEnumSectionMdx = (enums: Enum[]): string|null => {
-  if (enums.length == 0) {
-    return null;
-  }
-
-  return (
-    `## Enums
-
-${enums.map((enumb, i) => (
-`
-### \`${enumb.longName}\`
-<ProtoEnum key={${i}} enumb={${JSON.stringify(enumb)}} />
-`
-)).join("\n")}`
-  );
-}
-
-const generateServiceSectionMdx = (services: Service[]): string|null => {
-  if (services.length == 0) {
-    return null;
-  }
-
-  return (
-    `## Services
-
-${services.map((service, i) => (
-`
-### \`${service.name}\`
-
-${service.description}
-
-${service.methods.map((method, i) => (
-`
-#### \`${method.name}\`
-<ProtoServiceMethod key={'${method.name}-${i}'} method={${JSON.stringify(method)}} />
-`
-)).join("\n")}
-`
-)).join("\n")}`
-  );
-}

--- a/packages/docusaurus-protobuffet-plugin/src/generators/template.ts
+++ b/packages/docusaurus-protobuffet-plugin/src/generators/template.ts
@@ -1,0 +1,62 @@
+const template = `---
+title: {{getLeafFileName name}}
+hide_title: true
+---
+
+import { ProtoMessage, ProtoServiceMethod, ProtoEnum } from '@theme/ProtoFile';
+
+# \`{{getLeafFileName name}}\`
+_**path** {{{name}}}_
+
+_**package** {{{package}}}_
+
+{{{description}}}
+
+---
+
+{{#if messages}}
+## Messages
+
+{{#each messages}}
+
+### \`{{{longName}}}\`
+<ProtoMessage key=\{ {{~@index~}} \} message=\{ {{~{stringify this}~}} \} />
+
+{{/each}}
+---
+{{/if}}
+{{#if enums}}
+## Enums
+
+
+{{#each enums}}
+### \`{{{longName}}}\`
+<ProtoEnum key=\{ {{~@index~}} \} enumb=\{ {{~{stringify this}~}} \} />
+
+{{/each}}
+---
+{{/if}}
+{{#if services}}
+## Services
+
+{{#each services}}
+
+### \`{{{name}}}\`
+
+{{{description}}}
+
+
+{{#each methods}}
+#### \`{{name}}\`
+<ProtoServiceMethod key=\{'{{~name}}-{{@index}}'\} method=\{ {{~{stringify this}~}} \} />
+
+
+{{/each}}
+{{/each}}
+---
+{{/if}}
+
+
+  `;
+
+export default template;

--- a/packages/docusaurus-protobuffet-plugin/src/index.ts
+++ b/packages/docusaurus-protobuffet-plugin/src/index.ts
@@ -1,45 +1,72 @@
-import { Plugin, LoadContext } from "@docusaurus/types"
-import { existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
-import path from 'path';
+import { Plugin, LoadContext } from "@docusaurus/types";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "fs";
+import path from "path";
 
-import { generateDocFiles, generateSidebarFileContents } from './generators';
-import { parseFileDescriptors } from './parsers';
+import { generateDocFiles, generateSidebarFileContents } from "./generators";
+import { parseFileDescriptors } from "./parsers";
 
 export interface PluginOptions {
   // Path to Protobuf file descriptors JSON file. See: https://protobuffet.com/docs/how/usage#generating-the-filedescriptorspath-file
-  fileDescriptorsPath: string
+  fileDescriptorsPath: string;
   // Path to generate data on filesystem relative to site dir.
   protoDocsPath: string;
   // Path to sidebar configuration for showing a list of markdown pages.
   sidebarPath: string;
   // URL route for the docs section of your site.
   routeBasePath: string;
+  // Optional: Path to the custom document template file. The template uses the Handlebars format.
+  templatePath?: string;
 }
 
-export function validateOptions({ options, validate }: { options: PluginOptions, validate: () => void }): PluginOptions {
-  const { fileDescriptorsPath, protoDocsPath, sidebarPath } = options;
+export function validateOptions({
+  options,
+  validate,
+}: {
+  options: PluginOptions;
+  validate: () => void;
+}): PluginOptions {
+  const { fileDescriptorsPath, protoDocsPath, sidebarPath, templatePath } =
+    options;
 
   // fileDescriptorsPath is an existing json file
   if (!fileDescriptorsPath || !existsSync(fileDescriptorsPath)) {
-    throw new Error('Expected fileDescriptorsPath option to reference a present file.');
+    throw new Error(
+      "Expected fileDescriptorsPath option to reference a present file."
+    );
   }
 
   // protoDocsPath is a directory. we only check if it's a directory if it already exists.
-  if (!protoDocsPath || (existsSync(protoDocsPath) && !lstatSync(protoDocsPath).isDirectory())) {
-    throw new Error('Expected protoDocsPath option to reference a directory.');
+  if (
+    !protoDocsPath ||
+    (existsSync(protoDocsPath) && !lstatSync(protoDocsPath).isDirectory())
+  ) {
+    throw new Error("Expected protoDocsPath option to reference a directory.");
   }
 
   // sidebarPath is a present file
   if (!sidebarPath) {
-    throw new Error('Expected sidebarPath option to reference a file.');
+    throw new Error("Expected sidebarPath option to reference a file.");
+  }
+
+  // templatePath is optional, but when set, check if the file exists
+  if (templatePath && !existsSync(templatePath)) {
+    throw new Error(
+      `Could not find the template file "${templatePath}" referenced in option templatePath.`
+    );
   }
 
   return options;
-};
+}
 
 export default function plugin(
   context: LoadContext,
-  options: PluginOptions,
+  options: PluginOptions
 ): Plugin<never> {
   return {
     name: "docusaurus-protobuffet-plugin",
@@ -50,14 +77,24 @@ export default function plugin(
         .description("Generate documentation for a protobuf workspace.")
         .action(() => {
           // read file descriptors JSON file
-          const fileDescriptorsInput = JSON.parse(readFileSync(options.fileDescriptorsPath).toString());
-          const fileDescriptors = parseFileDescriptors(fileDescriptorsInput, options.routeBasePath);
+          const fileDescriptorsInput = JSON.parse(
+            readFileSync(options.fileDescriptorsPath).toString()
+          );
+          const fileDescriptors = parseFileDescriptors(
+            fileDescriptorsInput,
+            options.routeBasePath
+          );
+
+          // read a document template file
+          const template = options.templatePath
+            ? readFileSync(options.templatePath).toString()
+            : undefined;
 
           // generate markdown files for each in fileDescriptors
-          const docFiles = generateDocFiles(fileDescriptors);
+          const docFiles = generateDocFiles(fileDescriptors, template);
 
           // write files to appropriate directories
-          docFiles.forEach(docFile => {
+          docFiles.forEach((docFile) => {
             const fileName = `${options.protoDocsPath}/${docFile.fileName}.mdx`;
             const fileDir = path.dirname(fileName);
 
@@ -73,11 +110,11 @@ export default function plugin(
 
           // write sidebar object
           writeFileSync(options.sidebarPath, sidebarFileContents);
-        })
+        });
     },
 
     getThemePath() {
       return path.resolve(__dirname, "./theme");
-    }
-  }
+    },
+  };
 }

--- a/packages/docusaurus-protobuffet/src/index.ts
+++ b/packages/docusaurus-protobuffet/src/index.ts
@@ -1,4 +1,4 @@
-import { LoadContext } from '@docusaurus/types';
+import { LoadContext } from "@docusaurus/types";
 
 interface PluginOptions {
   // Path to Protobuf file descriptors JSON file. See: https://protobuffet.com/docs/how/usage#generating-the-filedescriptorspath-file
@@ -9,6 +9,8 @@ interface PluginOptions {
   sidebarPath?: string;
   // URL base route for the Protobuffet docs section of your site. Not configurable by user here, is assigned using doc option's routeBasePath.
   routeBasePath?: string;
+  // Optional: Path to the custom document template file. The template uses the Handlebars format.
+  templatePath?: string;
 }
 
 const pluginOptionDefaults = {


### PR DESCRIPTION
# Motivation and Context

*TLDR - skip to the Problem section*

I am searching for a solution for our product that will allow us to have a single documentation with both REST API and gRPC API reference. It seems that using Docusaurus + [OpenAPI Docs](https://docusaurus-openapi.tryingpan.dev/) + Protobuffet could be feasible.

I found out that I will most likely need to make some customizations:

1. First, our developers want to use Markdown format for description fields in protobuf. I found out that it is possible to "swizzle" the `ProtoFile` component (thanks for this possibility) and I extended the original components with using ReactMarkdown. These changes were done in my code without the need to modify Protobuffet.
2. Second, I will probably need to make some minor changes to the output MDX document structure, at least in the Front Matter metadata section. Currently, it is hardcoded, and it will require some changes in Protobuffet.

I noticed that the OpenAPI Docs plugin gives the possibility to pass your own template to customize the generated MDX content. I think this feature could be useful for Protobuffet as well. My initial plan was to use the same templating library as the one used in OpenAPI Docs - [Mustache](https://mustache.github.io/). However, as I wanted to implement this feature without any breaking changes in the output, I had to choose something a little more powerful than Mustache since it does not provide the possibility to render indexes (which is needed in `key={}` attributes). Therefore, I chose [Handlebars](https://handlebarsjs.com/) which is similar to Mustache and provides `@index`. Additionally, [custom helpers](https://handlebarsjs.com/guide/#custom-helpers) can be useful as well.

# Problem

The generated MDX content is hardcoded, and it can't be customized. At least, it would be nice to customize the Front Matter section. Additionally, other things like strings ("Messages", "Enums", etc.) could be customizable for l18n purposes.

# Proposed solution

I added an optional `protobuffet.templatePath` parameter, which brings the possibility to customize the generated content's template.

# Usage

To configure a custom template, specify the path to your  template file in the `protobuffet.templatePath` parameter.

Example config:

```js
[
  'docusaurus-protobuffet',
  {
    protobuffet: {
      ...
      templatePath: './template.hbs'
    },
    docs: {
      ...
    },
  }
]
```

Example (default) template:

*template.hbs*

```handlebars
---
title: {{getLeafFileName name}}
hide_title: true
---

import { ProtoMessage, ProtoServiceMethod, ProtoEnum } from '@theme/ProtoFile';

# \`{{getLeafFileName name}}\`
_**path** {{{name}}}_

_**package** {{{package}}}_

{{{description}}}

---


{{#if messages}}
## Messages

{{#each messages}}

### \`{{{longName}}}\`
<ProtoMessage key=\{ {{@index}} \} message=\{ {{{stringify this}}} \} />

{{/each}}
---
{{/if}}


{{#if enums}}
## Enums

{{#each enums}}
### \`{{{longName}}}\`
<ProtoEnum key=\{ {{@index}} \} enumb=\{ {{{stringify this}}} \} />

{{/each}}
---
{{/if}}


{{#if services}}
## Services

{{#each services}}

### \`{{{name}}}\`

{{{description}}}

{{#each methods}}
#### \`{{name}}\`
<ProtoServiceMethod key=\{'{{name}}-{{@index}}'\} method=\{ {{{stringify this}}} \} />

{{/each}}
{{/each}}
---
{{/if}}
```





---

Please let me know if you think this feature would be useful for your plugin or not. In the Road map I see - "Extension support for generated sidebar and **mdx files**". Maybe you plan to do it differently or more robustly - so then just ignore/close this PR. I also see that you haven't been very active on this project lately, so I decided to try to do it myself. Anyway, any feedback would be appreciated.